### PR TITLE
For postgres datatype DATE do not change that date (return new Date(d…

### DIFF
--- a/decode.ts
+++ b/decode.ts
@@ -10,24 +10,8 @@ const DATE_RE = /^(\d{1,})-(\d{2})-(\d{2})$/;
 const TIMEZONE_RE = /([Z+-])(\d{2})?:?(\d{2})?:?(\d{2})?/;
 const BC_RE = /BC$/;
 
-function decodeDate(dateStr: string): null | Date {
-  const matches = DATE_RE.exec(dateStr);
-
-  if (!matches) {
-    return null;
-  }
-
-  const year = parseInt(matches[1], 10);
-  // remember JS dates are 0-based
-  const month = parseInt(matches[2], 10) - 1;
-  const day = parseInt(matches[3], 10);
-  const date = new Date(year, month, day);
-  // use `setUTCFullYear` because if date is from first
-  // century `Date`'s compatibility for millenium bug
-  // would set it as 19XX
-  date.setUTCFullYear(year);
-
-  return date;
+function decodeDate(dateStr: string): Date {
+  return new Date(dateStr + 'T00:00:00Z');
 }
 /**
  * Decode numerical timezone offset from provided date string.


### PR DESCRIPTION
…ateStr + 'T00:00:00Z')

/* text of issue https://github.com/deno-postgres/deno-postgres/issues/181 copied */
Currently I get my dates (defined with datatype DATE) back as f.e. "2021-03-02T23:00:00.000Z" while pgadmin gives 2021-03-03. So I get the wrong date back (and a timestamp was added).
You can find the same issue in node-postgres brianc/node-postgres#818 where someone suggests a workaround in the end (that I just tested, it works). brianc/node-postgres#818 , see a paste of the snippet below. Can this be fixed in deno-postgres? My proposal would be to change decodeDate in decode.ts to simply

function decodeDate(dateStr: string): Date {
    return new Date(dateStr + 'T00:00:00Z');
}
of course that works for year 0001 too. ;-) For null values in the postgress date the function decodeDate is not executed.

/* Node postgres date fix /
var Moment = require('moment');
var parseDate = function parseDate(val) {
return val === null ? null : Moment(val).format('YYYY-MM-DD')
};
var types = pg.types;
var DATATYPE_DATE = 1082;
types.setTypeParser(DATATYPE_DATE, function(val) {
return val === null ? null : parseDate(val)
});
/ Node postgres date fix - end */